### PR TITLE
Changed duplicate language lookup from Chinese to English

### DIFF
--- a/state.py
+++ b/state.py
@@ -79,7 +79,7 @@ class R(BaseState):
         WS_DONE: 'Websocket 请求完成'
     }
 
-    _lang_cn = {
+    _lang_en = {
         SUCCESS: 'success',
         FAILED: 'failed',
         TIMEOUT: 'timeout',


### PR DESCRIPTION
The default language is Chinese (cn) but the alternate option should be English (en)